### PR TITLE
Remove duplicate LLM module sections

### DIFF
--- a/03_modern-Ai/01_llms.md
+++ b/03_modern-Ai/01_llms.md
@@ -61,50 +61,21 @@ Covers:
 - Embeddings and vector stores (FAISS, ChromaDB)
 - Hybrid search and document injection
 
-### 5. LLM Security & Ethics
+### 5. LLM Security, Ethics & Evaluation
 
 - [AI Security & Safety (DeepMind)](https://deepmind.com/research/publications/2023/ai-safety-and-security) — **Free**
 - [Responsible AI Practices (Google)](https://ai.google/responsibilities/responsible-ai-practices/) — **Free**
 - [LLM Security Risks (OWASP)](https://owasp.org/www-community/attacks/LLM_Attacks) — **Free**
-
-Covers:
-- Security risks in LLM deployment
-- Bias, fairness, and responsible use
-- Mitigation strategies and best practices
-- Building chatbots, agents, and tools
-- Prompt injection and safety
-
-### 3. Open-Source LLMs
-
-- [Hugging Face Transformers Course](https://huggingface.co/learn/nlp-course/) — **Free**
-- [Running LLaMA or Mistral on Local Hardware – Guides](https://huggingface.co/blog/llama2) — **Free**
-
-Covers:
-- Working with models like LLaMA 2, Mistral, Falcon
-- Loading models via `transformers` and `transformers.js`
-- Tokenizers, inference speed, quantization
-
-### 4. Fine-Tuning & Retrieval-Augmented Generation (RAG)
-
-- [Fine-tuning LLMs with LoRA – Hugging Face](https://huggingface.co/blog/lora) — **Free**
-- [RAG with Haystack or LangChain – Tutorials](https://www.youtube.com/watch?v=Lk4TzDNsCzU) — **Free**
-- [Full-Stack LLM Bootcamp – Cohere](https://fullstackdeeplearning.com/llm-bootcamp/) — **Free**
-
-Covers:
-- Fine-tuning with LoRA/QLoRA
-- Embeddings and vector stores (FAISS, ChromaDB)
-- Hybrid search and document injection
-
-### 5. Ethics, Safety & Evaluation
-
 - [Responsible AI with LLMs – DeepLearning.AI Short Course](https://www.deeplearning.ai/short-courses/responsible-llms/) — **Free**
 - [Red Teaming LLMs – Anthropic Blog](https://www.anthropic.com/index/2023/07/red-teaming-ai/) — **Free**
 - [Prompt Injection Guide – OWASP](https://owasp.org/www-community/attacks/Prompt_Injection) — **Free**
 
 Covers:
-- Bias, hallucination, toxicity
-- Jailbreaks and adversarial prompting
+- Security risks in LLM deployment
+- Prompt injection, jailbreaks, and adversarial prompting
+- Bias, fairness, hallucination, and toxicity
 - Model evaluation and safety tools
+- Mitigation strategies and responsible AI practices
 
 ## Suggested Projects & Practice
 


### PR DESCRIPTION
Cleaned up repeated content in the LLM module by removing duplicate sections and consolidating overlapping security, ethics, and evaluation topics into a single section. Also removed misplaced repeated bullets to improve structure and readability.